### PR TITLE
fix: fix sending wrong dates in timeslider

### DIFF
--- a/apps/eodh-fe/src/app/layout/bottom-panel.component.tsx
+++ b/apps/eodh-fe/src/app/layout/bottom-panel.component.tsx
@@ -13,10 +13,8 @@ export const BottomPanel = ({ className }: IBottomPanel) => {
   }
 
   return (
-    <div
+    <TimelineAnalyticsDashboard
       className={`w-full h-[76px] bg-background-main border-b-[1px] border-bright-dark flex items-center text-text bottom-0 ${className}`}
-    >
-      <TimelineAnalyticsDashboard className='grow' />
-    </div>
+    />
   );
 };

--- a/libs/map/data-access-stac-catalog/src/lib/query-builder/filter-params/date-time.filter-params.ts
+++ b/libs/map/data-access-stac-catalog/src/lib/query-builder/filter-params/date-time.filter-params.ts
@@ -1,4 +1,4 @@
-import { createIsoStringDate } from '@ukri/shared/utils/date';
+import { createDate, createDateString, createIsoStringDate } from '@ukri/shared/utils/date';
 
 import { TFilterParam, TSearchParams } from '../query.model';
 
@@ -7,12 +7,22 @@ export const createDateTimeFilterParams = (params: TSearchParams): TFilterParam 
     return null;
   }
 
+  const dateFrom = createDate(params.date.from);
+  const dateTo = createDate(params.date.to);
+
+  if (!dateFrom || !dateTo) {
+    return null;
+  }
+
+  dateFrom.setUTCHours(0, 0, 0, 0);
+  dateTo.setUTCHours(23, 59, 59, 999);
+
   return {
     op: 'between',
     args: [
       { property: 'properties.datetime' },
-      createIsoStringDate(params.date.from),
-      createIsoStringDate(params.date.to),
+      createIsoStringDate(createDateString(dateFrom)),
+      createIsoStringDate(createDateString(dateTo)),
     ],
   };
 };

--- a/libs/map/data-access-stac-catalog/src/lib/stac-catalog.query.tsx
+++ b/libs/map/data-access-stac-catalog/src/lib/stac-catalog.query.tsx
@@ -52,5 +52,6 @@ export const useCatalogSearch = ({ params }: TCatalogSearchProps) => {
     enabled: query.enabled,
     queryKey: queryKey.CATALOG_SEARCH(query.params),
     queryFn: () => getResults(query.params, params),
+    staleTime: 200,
   });
 };

--- a/libs/map/feature-timeline-analytics-dashboard/src/lib/timeline-analytics-dashboard.component.tsx
+++ b/libs/map/feature-timeline-analytics-dashboard/src/lib/timeline-analytics-dashboard.component.tsx
@@ -7,20 +7,23 @@ type TActionCreatorPanelProps = {
 };
 
 export const TimelineAnalyticsDashboard = ({ className }: TActionCreatorPanelProps) => {
-  const { minDate, maxDate, selectedMinDate, selectedMaxDate, updateSelectedDate } = useTimelineAnalytics();
+  const { status, minDate, maxDate, selectedMinDate, selectedMaxDate, updateSelectedDate } = useTimelineAnalytics();
 
   if (!minDate || !maxDate) {
     return null;
   }
 
   return (
-    <TimeSlider
-      min={minDate}
-      max={maxDate}
-      selectedMin={selectedMinDate}
-      selectedMax={selectedMaxDate}
-      className={className}
-      onUpdate={updateSelectedDate}
-    />
+    <div className={className}>
+      <TimeSlider
+        min={minDate}
+        max={maxDate}
+        selectedMin={selectedMinDate}
+        selectedMax={selectedMaxDate}
+        className='grow'
+        onUpdate={updateSelectedDate}
+        disabled={status === 'pending'}
+      />
+    </div>
   );
 };

--- a/libs/shared/ui/time-slider/src/lib/time-slider.tsx
+++ b/libs/shared/ui/time-slider/src/lib/time-slider.tsx
@@ -35,6 +35,7 @@ interface ITimeSliderProps {
   selectedMin?: TDate;
   selectedMax?: TDate;
   className?: string;
+  disabled?: boolean;
   onUpdate: (dateFrom: NonNullable<TDateString>, dateTo: NonNullable<TDateString>) => void;
 }
 
@@ -42,9 +43,10 @@ export const TimeSlider = ({
   min,
   max,
   selectedMin = min,
-  selectedMax = min,
+  selectedMax = max,
   onUpdate,
   className,
+  disabled,
 }: ITimeSliderProps) => {
   const minNum = getBeginingOfYear(min) ?? undefined;
   const maxNum = getEndYear(max) ?? undefined;
@@ -68,7 +70,7 @@ export const TimeSlider = ({
     <div className={`${sliderStyles.container} ${className}`}>
       <div className={sliderStyles.innerContainer}>
         <Slider
-          value={[dateToNumber(selectedMin) ?? 0, dateToNumber(selectedMax) ?? 0]}
+          value={[dateToNumber(selectedMin, 'firstDay') ?? 0, dateToNumber(selectedMax, 'lastDay') ?? 0]}
           onChange={updateSliderValue}
           valueLabelDisplay='auto'
           min={minNum}
@@ -81,6 +83,7 @@ export const TimeSlider = ({
             markLabel: CustomLabel,
           }}
           className={sliderStyles.slider}
+          disabled={disabled}
         />
       </div>
     </div>

--- a/libs/shared/utils/date/src/lib/date.utils.ts
+++ b/libs/shared/utils/date/src/lib/date.utils.ts
@@ -13,7 +13,7 @@ export type TDateString = TDateInternal | null;
 
 type TDateFormat = 'DD/MM/YYYY' | 'YYYY-MM-DD' | 'DD-MM-YY';
 
-export const dateToNumber = (date: TDateTimeString | TDateString): number | null => {
+export const dateToNumber = (date: TDateTimeString | TDateString, type: 'firstDay' | 'lastDay'): number | null => {
   const d = createDate(date);
   if (d === null) {
     // eslint-disable-next-line no-console
@@ -21,7 +21,11 @@ export const dateToNumber = (date: TDateTimeString | TDateString): number | null
     return null;
   }
 
-  return d.getFullYear() + d.getMonth() / 12;
+  const dateWithFirstDayOfMonth = new Date(d.getFullYear(), d.getMonth(), 1);
+  const dateWithLastDayOfMonth = new Date(d.getFullYear(), d.getMonth() + 1, 0);
+  const newDate = type === 'firstDay' ? dateWithFirstDayOfMonth : dateWithLastDayOfMonth;
+
+  return newDate.getFullYear() + newDate.getMonth() / 12;
 };
 
 export const numberToDateString = (num: number, monthEnd?: boolean): TDateString => {
@@ -43,7 +47,7 @@ export const getEndYear = (date: TDateString): number | null => {
   }
 
   adjustedDate.setMonth(0, 1);
-  const result = dateToNumber(formatDate(createDateString(adjustedDate)));
+  const result = dateToNumber(formatDate(createDateString(adjustedDate)), 'lastDay');
 
   if (result === null) {
     // eslint-disable-next-line no-console
@@ -61,7 +65,7 @@ export const getBeginingOfYear = (date: TDateString): number | null => {
   }
 
   adjustedDate.setMonth(0, 1);
-  const result = dateToNumber(formatDate(createDateString(adjustedDate)));
+  const result = dateToNumber(formatDate(createDateString(adjustedDate)), 'firstDay');
 
   if (result === null) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
- fix sending wrong dates in timeslider
- add disable state for timeslider (styles still missing)
- hide bottom panel if slider shouldn't be displayed
- update params sent to STAC API to include start/end of the day (hours for start and end of the day)

Tickets:
- https://ukri-spyrosoft.atlassian.net/browse/UKRIW-576