### PR TITLE
[UKRIW-842] fix: updating data set state when ac is not enabled

### DIFF
--- a/libs/map/data-access-map/src/lib/query/presets/presets.query.tsx
+++ b/libs/map/data-access-map/src/lib/query/presets/presets.query.tsx
@@ -11,11 +11,15 @@ const presets = async (): Promise<TPreset[]> => {
   return presetsSchema.parse(response).presets;
 };
 
-export const useGetPresets = () => {
+type TGetPresetsOptions = {
+  enabled?: boolean;
+};
+
+export const useGetPresets = ({ enabled = true }: TGetPresetsOptions) => {
   return useQuery<TExtractFnReturnType<typeof presets>>({
     queryKey: queryKey.PRESETS(),
     queryFn: () => presets(),
-    enabled: true,
+    enabled,
     staleTime: 60 * 1000,
   });
 };

--- a/libs/map/feature-action-creator-panel/src/lib/action-creator-panel.context.tsx
+++ b/libs/map/feature-action-creator-panel/src/lib/action-creator-panel.context.tsx
@@ -50,6 +50,7 @@ export const ActionCreatorProvider = ({ children }: PropsWithChildren) => {
     context: { showOnboardingTooltip, hideOnboardingTooltip, enableOnboarding, disableOnboarding },
   } = useOnboarding();
   const { isOpen: isTabsFlowModalOpen } = useTabsFlowModalState();
+  const actionCreatorEnabled = useMemo(() => mode === 'action-creator', [mode]);
 
   useWorkflowStatus({ enabled: shouldEnableWorkflow });
 
@@ -93,9 +94,11 @@ export const ActionCreatorProvider = ({ children }: PropsWithChildren) => {
       }
 
       setActiveTab(newTab);
-      toggleActionCreatorState(newTab);
+      if (actionCreatorEnabled) {
+        toggleActionCreatorState(newTab);
+      }
     },
-    [activeTab, markAsRead, setActiveTab, switchView, toggleActionCreatorState]
+    [activeTab, markAsRead, setActiveTab, switchView, actionCreatorEnabled, toggleActionCreatorState]
   );
 
   const toggle = useCallback(() => {
@@ -127,7 +130,7 @@ export const ActionCreatorProvider = ({ children }: PropsWithChildren) => {
   ]);
 
   return (
-    <ActionCreator.Provider value={{ collapsed, collapse, toggle, changeTab, enabled: mode === 'action-creator' }}>
+    <ActionCreator.Provider value={{ collapsed, collapse, toggle, changeTab, enabled: actionCreatorEnabled }}>
       {children}
     </ActionCreator.Provider>
   );

--- a/libs/map/feature-action-creator-panel/src/lib/content/history/use-history-data.hook.ts
+++ b/libs/map/feature-action-creator-panel/src/lib/content/history/use-history-data.hook.ts
@@ -1,5 +1,7 @@
 import { IHistoryParams, THistory, THistoryItem, useGetHistory } from '@ukri/map/data-access-map';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
+
+import { ActionCreator } from '../../action-creator-panel.context';
 
 const getSortOrder = (orderBy: TOrderBy): 'desc' | 'asc' => {
   switch (orderBy) {
@@ -35,7 +37,11 @@ export const useHistoryData = (): IUseHistoryData => {
   const params: IHistoryParams = {
     orderDirection: getSortOrder(orderBy),
   };
-  const { data, error, isLoading, isFetching, refetch, hasNextPage, fetchNextPage } = useGetHistory({ params });
+  const { enabled } = useContext(ActionCreator);
+  const { data, error, isLoading, isFetching, refetch, hasNextPage, fetchNextPage } = useGetHistory({
+    params,
+    enabled,
+  });
 
   const changeOrder = useCallback((order: TOrderBy) => {
     setOrderBy(order);

--- a/libs/map/feature-action-creator-panel/src/lib/content/presets/presets.component.tsx
+++ b/libs/map/feature-action-creator-panel/src/lib/content/presets/presets.component.tsx
@@ -50,10 +50,10 @@ const PresetsContainer = ({ children }: PropsWithChildren) => {
 };
 
 export const Presets = () => {
-  const { data, error, isLoading, refetch } = useGetPresets();
-  const { data: functionData } = useFunctions();
+  const { enabled, changeTab } = useContext(ActionCreator);
+  const { data, error, isLoading, refetch } = useGetPresets({ enabled });
+  const { data: functionData } = useFunctions({ enabled });
   const { loadPreset } = useActionCreator();
-  const { changeTab } = useContext(ActionCreator);
   const { changeView } = useMode();
   const status = useCreateWorkflowStatus();
   const {

--- a/libs/map/feature-action-creator-panel/src/lib/content/workflow/nodes/function/function-node.component.tsx
+++ b/libs/map/feature-action-creator-panel/src/lib/content/workflow/nodes/function/function-node.component.tsx
@@ -8,9 +8,10 @@ import {
   useFunctions,
 } from '@ukri/map/data-access-map';
 import { useOnboarding } from '@ukri/shared/ui/ac-workflow-onboarding';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ActionCreator } from '../../../../action-creator-panel.context';
 import { useActiveDataSet } from '../data-set/use-active-dataset.hook';
 import { EmptyNode } from '../empty-node.component';
 import { TOption, TValue } from '../node-select.component';
@@ -115,11 +116,12 @@ interface IFunctionNodeProps {
 }
 
 export const NodeFunction = ({ node }: IFunctionNodeProps) => {
+  const { enabled } = useContext(ActionCreator);
   const {
     context: { goToNextOnboardingStep, onboardingSteps },
   } = useOnboarding();
   const { setActiveNode, setValue, canActivateNode } = useActionCreator();
-  const { data, isLoading } = useFunctions();
+  const { data, isLoading } = useFunctions({ enabled });
   const nodeRef = useRef<HTMLDivElement>(null);
   const canBeActivated = useMemo(() => canActivateNode(node), [node, canActivateNode]);
 


### PR DESCRIPTION
- fix: update Data Sets only when AC is enabled. Right now switching tabs in AC when AC is collapsed won't update Data Sets
- fix: call BE (presets/functions/history) only when AC is enabled. Right now if AC is collapsed (not enabled) no queries will be made

Tickets:
- https://ukri-spyrosoft.atlassian.net/browse/UKRIW-842