### PR TITLE
[UKRIW-856] feat: move throttle function to useRef as it was not fired at all

### DIFF
--- a/libs/shared/design-system/src/lib/slider/slider.tsx
+++ b/libs/shared/design-system/src/lib/slider/slider.tsx
@@ -27,6 +27,7 @@ export const Slider = forwardRef(
   ({ name, max = 100, onChange, onBlur, disabled }: ISliderProps, ref: ForwardedRef<HTMLInputElement | undefined>) => {
     const innerRef = useRef<HTMLInputElement>(null);
     const [sliderValue, setSliderValue] = useState(innerRef?.current ? parseInt(innerRef.current.value) : 0);
+    const throttledRef = useRef(throttle((cb: () => void) => cb(), 1000));
 
     useImperativeHandle(ref, () => (innerRef.current ? innerRef.current : undefined));
 
@@ -43,8 +44,7 @@ export const Slider = forwardRef(
       (event: ChangeEvent<HTMLInputElement>) => {
         const value = Number(event.target.value);
         setSliderValue(value);
-
-        return throttle((event: ChangeEvent<HTMLInputElement>) => onChange(event), 100);
+        throttledRef.current(() => onChange(event));
       },
       [onChange]
     );


### PR DESCRIPTION
Change throtle callback to useRefs. Without it, it won't be fired. Further reading:
- https://stackoverflow.com/questions/54666401/how-to-use-throttle-or-debounce-with-react-hook
- https://overreacted.io/making-setinterval-declarative-with-react-hooks
- https://css-tricks.com/debouncing-throttling-explained-examples

Tickets:
- https://ukri-spyrosoft.atlassian.net/browse/UKRIW-856