### PR TITLE
[UKRIW-898] feat: remove CORINE, Water Bodies and RapidEye from Data Sets

### DIFF
--- a/@types/i18next/resources.d.ts
+++ b/@types/i18next/resources.d.ts
@@ -260,8 +260,6 @@ interface Resources {
               SENTINEL_5P: 'Sentinel-5P';
               AUXILIARY: {
                 GLOBAL_LAND_COVER: 'Global Land Cover';
-                CORINE_LAND_COVER: 'CORINE Land Cover';
-                WATER_BODIES: 'Water Bodies';
               };
             };
             DATE_RANGE: {
@@ -1337,16 +1335,11 @@ interface Resources {
               SKY_SAT: {
                 NAME: 'SkySat';
               };
-              RAPID_EYE: {
-                NAME: 'RapidEye';
-              };
               MAX_CLOUD_COVERAGE: 'Max cloud coverage:';
             };
             AUXILIARY: {
               NAME: 'Auxiliary';
               GLOBAL_LAND_COVER: 'Global Land Cover';
-              CORINE_LAND_COVER: 'CORINE Land Cover';
-              WATER_BODIES: 'Water Bodies';
             };
             COPERNICUS: {
               NAME: 'Copernicus';

--- a/apps/eodh-fe/public/assets/i18n/en.json
+++ b/apps/eodh-fe/public/assets/i18n/en.json
@@ -258,9 +258,7 @@
             "SENTINEL_3": "Sentinel-3",
             "SENTINEL_5P": "Sentinel-5P",
             "AUXILIARY": {
-              "GLOBAL_LAND_COVER": "Global Land Cover",
-              "CORINE_LAND_COVER": "CORINE Land Cover",
-              "WATER_BODIES": "Water Bodies"
+              "GLOBAL_LAND_COVER": "Global Land Cover"
             }
           },
           "DATE_RANGE": {
@@ -1336,16 +1334,11 @@
             "SKY_SAT": {
               "NAME": "SkySat"
             },
-            "RAPID_EYE": {
-              "NAME": "RapidEye"
-            },
             "MAX_CLOUD_COVERAGE": "Max cloud coverage:"
           },
           "AUXILIARY": {
             "NAME": "Auxiliary",
-            "GLOBAL_LAND_COVER": "Global Land Cover",
-            "CORINE_LAND_COVER": "CORINE Land Cover",
-            "WATER_BODIES": "Water Bodies"
+            "GLOBAL_LAND_COVER": "Global Land Cover"
           },
           "COPERNICUS": {
             "NAME": "Copernicus",

--- a/libs/map/data-access-map/src/lib/form-builder/tree/data-sets.model.ts
+++ b/libs/map/data-access-map/src/lib/form-builder/tree/data-sets.model.ts
@@ -36,14 +36,6 @@ export type TDataSetsValues = {
         enabled?: boolean;
         expanded?: boolean;
       };
-      clmsCorinelc?: {
-        enabled?: boolean;
-        expanded?: boolean;
-      };
-      clmsWaterBodies?: {
-        enabled?: boolean;
-        expanded?: boolean;
-      };
     };
   };
   private: {
@@ -55,9 +47,6 @@ export type TDataSetsValues = {
         enabled?: boolean;
       };
       skySat?: {
-        enabled?: boolean;
-      };
-      rapidEye?: {
         enabled?: boolean;
       };
       cloudCoverage?: number;

--- a/libs/map/data-access-map/src/lib/form-builder/tree/schema/auxiliary.schema.ts
+++ b/libs/map/data-access-map/src/lib/form-builder/tree/schema/auxiliary.schema.ts
@@ -21,25 +21,5 @@ export const auxiliarySchema: IDynamicTreeCategory = {
         },
       },
     },
-    {
-      translationKey: 'MAP.SEARCH_VIEW.DATA_SETS.DATA_SETS_CONFIGURATION.AUXILIARY.CORINE_LAND_COVER',
-      type: 'item',
-      controls: {
-        value: {
-          name: 'public.auxiliary.clmsCorinelc.enabled',
-          type: 'checkbox',
-        },
-      },
-    },
-    {
-      translationKey: 'MAP.SEARCH_VIEW.DATA_SETS.DATA_SETS_CONFIGURATION.AUXILIARY.WATER_BODIES',
-      type: 'item',
-      controls: {
-        value: {
-          name: 'public.auxiliary.clmsWaterBodies.enabled',
-          type: 'checkbox',
-        },
-      },
-    },
   ],
 };

--- a/libs/map/data-access-map/src/lib/form-builder/tree/schema/planet.schema.ts
+++ b/libs/map/data-access-map/src/lib/form-builder/tree/schema/planet.schema.ts
@@ -22,20 +22,6 @@ const skySatSchema: IDynamicTreeItem = {
   },
 };
 
-const rapidEyeSchema: IDynamicTreeItem = {
-  translationKey: 'MAP.SEARCH_VIEW.DATA_SETS.DATA_SETS_CONFIGURATION.PLANET.RAPID_EYE.NAME',
-  type: 'item',
-  controls: {
-    value: {
-      name: 'private.planet.rapidEye.enabled',
-      type: 'checkbox',
-    },
-  },
-  options: {
-    disabled: true,
-  },
-};
-
 const cloudCoverage: IDynamicSlider = {
   translationKey: 'MAP.SEARCH_VIEW.DATA_SETS.DATA_SETS_CONFIGURATION.PLANET.MAX_CLOUD_COVERAGE',
   type: 'slider',
@@ -61,7 +47,7 @@ export const planetSearchSchema: IDynamicTreeCategory = {
       value: false,
     },
   },
-  children: [planetScopeSchema, skySatSchema, rapidEyeSchema, cloudCoverage],
+  children: [planetScopeSchema, skySatSchema, cloudCoverage],
 };
 
 export const planetActionCreatorSchema: IDynamicTreeCategory = {
@@ -82,5 +68,5 @@ export const planetActionCreatorSchema: IDynamicTreeCategory = {
   options: {
     disabled: true,
   },
-  children: [planetScopeSchema, skySatSchema, rapidEyeSchema, cloudCoverage],
+  children: [planetScopeSchema, skySatSchema, cloudCoverage],
 };

--- a/libs/map/data-access-map/src/lib/store/data-sets/utils.tsx
+++ b/libs/map/data-access-map/src/lib/store/data-sets/utils.tsx
@@ -69,26 +69,6 @@ export const getValuesForDataSet = (
 
       break;
     }
-
-    case 'clms-corinelc': {
-      if (!state.dataSets.public.auxiliary?.clmsCorinelc) {
-        return state;
-      }
-
-      set(newValues, 'public.auxiliary.clmsCorinelc.enabled', true);
-
-      break;
-    }
-
-    case 'clms-water-bodies': {
-      if (!state.dataSets.public.auxiliary?.clmsWaterBodies) {
-        return state;
-      }
-
-      set(newValues, 'public.auxiliary.clmsWaterBodies.enabled', true);
-
-      break;
-    }
   }
 
   return { dataSets: newValues };

--- a/libs/map/data-access-map/src/lib/store/results/results.model.ts
+++ b/libs/map/data-access-map/src/lib/store/results/results.model.ts
@@ -36,9 +36,6 @@ type TDataSets = {
       skySat?: {
         enabled?: boolean;
       };
-      rapidEye?: {
-        enabled?: boolean;
-      };
       cloudCoverage?: number;
     };
   };

--- a/libs/map/data-access-stac-catalog/src/lib/query-builder/comercial/planet.query-builder.ts
+++ b/libs/map/data-access-stac-catalog/src/lib/query-builder/comercial/planet.query-builder.ts
@@ -111,10 +111,6 @@ export class PlanetQueryBuilder {
       collections.push('SkySatScene');
     }
 
-    if (planet.rapidEye?.enabled) {
-      collections.push('REOrthoTile');
-    }
-
     return collections;
   };
 

--- a/libs/map/data-access-stac-catalog/src/lib/query-builder/query.model.ts
+++ b/libs/map/data-access-stac-catalog/src/lib/query-builder/query.model.ts
@@ -33,9 +33,6 @@ export type TPlanetSearchParams = {
   skySat?: {
     enabled?: boolean;
   };
-  rapidEye?: {
-    enabled?: boolean;
-  };
   cloudCoverage?: number;
 };
 
@@ -50,12 +47,6 @@ export type TCatalogSearchParams = {
       auxiliary?: {
         enabled?: boolean;
         esacciGloballc?: {
-          enabled?: boolean;
-        };
-        clmsCorinelc?: {
-          enabled?: boolean;
-        };
-        clmsWaterBodies?: {
           enabled?: boolean;
         };
       };

--- a/libs/map/data-access-stac-catalog/src/lib/stac-model/search.schema.ts
+++ b/libs/map/data-access-stac-catalog/src/lib/stac-model/search.schema.ts
@@ -104,24 +104,6 @@ const skySatPropertySchema = z
     gridCode: undefined,
   }));
 
-const rapidEyePropertySchema = z
-  .object({
-    datetime: z.custom<NonNullable<TDateString>>(
-      (value) => !z.string().datetime({ offset: true }).safeParse(value).error
-    ),
-    cloud_cover: z.number().transform((value) => value * 100),
-    cloudCoverage: z.never().optional(),
-    gridCode: z.never().optional(),
-    orbitState: z.never().optional(),
-    instrumentMode: z.never().optional(),
-    polarizations: z.never().optional(),
-  })
-  .transform((data) => ({
-    datetime: data.datetime,
-    cloudCoverage: data.cloud_cover,
-    gridCode: undefined,
-  }));
-
 const planetScopePropertySchema = z
   .object({
     datetime: z.custom<NonNullable<TDateString>>(
@@ -146,7 +128,6 @@ export const featureSearchSchema = featureGenericSchema.extend({
     sentinel1Element84PropertySchema,
     sentinel1CedaPropertySchema,
     skySatPropertySchema,
-    rapidEyePropertySchema,
     planetScopePropertySchema,
   ]),
   assets: z.object({

--- a/libs/map/feature-action-creator-panel/src/lib/content/workflow/nodes/data-set/use-active-dataset.hook.tsx
+++ b/libs/map/feature-action-creator-panel/src/lib/content/workflow/nodes/data-set/use-active-dataset.hook.tsx
@@ -36,14 +36,6 @@ export const useActiveDataSet = (): TUseActiveDataSet => {
     enabled.push('esacci-globallc');
   }
 
-  if (dataSets.public.auxiliary?.clmsCorinelc?.enabled) {
-    enabled.push('clms-corinelc');
-  }
-
-  if (dataSets.public.auxiliary?.clmsWaterBodies?.enabled) {
-    enabled.push('clms-water-bodies');
-  }
-
   const hasError =
     enabled.length > 1 || (enabled.length === 1 && enabled.some((item) => item === hotFixCollectionNotExistingOnBe));
 

--- a/libs/map/ui-search-view/src/lib/schema/data-sets.schema.ts
+++ b/libs/map/ui-search-view/src/lib/schema/data-sets.schema.ts
@@ -47,10 +47,7 @@ export const dataSetsSearchUpdateSchema = z
   .superRefine((schema, ctx) => {
     const isCopernicusSatelliteEnabled =
       schema.public.copernicus.sentinel1.enabled || schema.public.copernicus.sentinel2.enabled;
-    const isPlanetSatelliteEnabled =
-      schema.private.planet.planetScope.enabled ||
-      schema.private.planet.rapidEye.enabled ||
-      schema.private.planet.skySat.enabled;
+    const isPlanetSatelliteEnabled = schema.private.planet.planetScope.enabled || schema.private.planet.skySat.enabled;
 
     if (isCopernicusSatelliteEnabled && isPlanetSatelliteEnabled) {
       ctx.addIssue({
@@ -97,8 +94,6 @@ export const dataSetsActionCreatorUpdateSchema = z.object({
       const enabledItems = [
         schema.copernicus.sentinel1.enabled,
         schema.copernicus.sentinel2.enabled,
-        schema.auxiliary.clmsCorinelc.enabled,
-        schema.auxiliary.clmsWaterBodies.enabled,
         schema.auxiliary.esacciGloballc.enabled,
       ].filter((item) => !!item);
 
@@ -119,18 +114,6 @@ export const dataSetsActionCreatorUpdateSchema = z.object({
           code: z.ZodIssueCode.custom,
           message: notDisplayedErrorMessage,
           path: ['auxiliary.esacciGloballc.enabled'],
-        });
-
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: notDisplayedErrorMessage,
-          path: ['auxiliary.clmsCorinelc.enabled'],
-        });
-
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: notDisplayedErrorMessage,
-          path: ['auxiliary.clmsWaterBodies.enabled'],
         });
       }
     }),

--- a/libs/map/ui-search-view/src/lib/schema/data-sets/auxiliary.schema.ts
+++ b/libs/map/ui-search-view/src/lib/schema/data-sets/auxiliary.schema.ts
@@ -8,30 +8,10 @@ export const auxiliaryInitialSchema = z.object({
       expanded: z.boolean().optional(),
     })
     .optional(),
-  clmsCorinelc: z
-    .object({
-      enabled: z.boolean().optional(),
-      expanded: z.boolean().optional(),
-    })
-    .optional(),
-  clmsWaterBodies: z
-    .object({
-      enabled: z.boolean().optional(),
-      expanded: z.boolean().optional(),
-    })
-    .optional(),
 });
 
 export const auxiliaryUpdateGenericSchema = z.object({
   esacciGloballc: z.object({
-    enabled: z.boolean().optional(),
-    expanded: z.boolean().optional(),
-  }),
-  clmsCorinelc: z.object({
-    enabled: z.boolean().optional(),
-    expanded: z.boolean().optional(),
-  }),
-  clmsWaterBodies: z.object({
     enabled: z.boolean().optional(),
     expanded: z.boolean().optional(),
   }),

--- a/libs/map/ui-search-view/src/lib/schema/data-sets/planet.schema.ts
+++ b/libs/map/ui-search-view/src/lib/schema/data-sets/planet.schema.ts
@@ -13,11 +13,6 @@ export const planetInitialSchema = z.object({
       enabled: z.boolean().optional(),
     })
     .optional(),
-  rapidEye: z
-    .object({
-      enabled: z.boolean().optional(),
-    })
-    .optional(),
   cloudCoverage: z.number().min(0).max(100).optional(),
 });
 
@@ -28,9 +23,6 @@ export const planetUpdateSchema = z.object({
     enabled: z.boolean(),
   }),
   skySat: z.object({
-    enabled: z.boolean(),
-  }),
-  rapidEye: z.object({
     enabled: z.boolean(),
   }),
   cloudCoverage: z.number().min(0).max(100).optional(),


### PR DESCRIPTION
- remove Data Sets:
* CORINE, Water Bodies - those Data Sets aren't supported by SentinelHub anymore
* RapidEye - it is not supported by TPZ

Tickets:
- https://ukri-spyrosoft.atlassian.net/browse/UKRIW-898