### PR TITLE
[Ewem 28] Colormap preset nbr

### DIFF
--- a/libs/map/ui-map/src/lib/stac/color-map.color-map.ts
+++ b/libs/map/ui-map/src/lib/stac/color-map.color-map.ts
@@ -4,56 +4,73 @@ import z from 'zod';
 import { INamedColorMapOptions } from './color-map.model';
 import { IAsset } from './stac.model';
 
-const colorMapSchema = z.object({
-  name: z.union([
-    z.literal('jet'),
-    z.literal('hsv'),
-    z.literal('hot'),
-    z.literal('cool'),
-    z.literal('spring'),
-    z.literal('summer'),
-    z.literal('autumn'),
-    z.literal('winter'),
-    z.literal('bone'),
-    z.literal('copper'),
-    z.literal('greys'),
-    z.literal('YlOrRd'),
-    z.literal('bluered'),
-    z.literal('RdBu'),
-    z.literal('picnic'),
-    z.literal('rainbow-soft'),
-    z.literal('portland'),
-    z.literal('blackbody'),
-    z.literal('earth'),
-    z.literal('electric'),
-    z.literal('viridis'),
-    z.literal('inferno'),
-    z.literal('magma'),
-    z.literal('plasma'),
-    z.literal('warm'),
-    z.literal('cool'),
-    z.literal('rainbow'),
-    z.literal('bathymetry'),
-    z.literal('cdom'),
-    z.literal('chlorophyll'),
-    z.literal('density'),
-    z.literal('freesurface-blue'),
-    z.literal('freesurface-red'),
-    z.literal('oxygen'),
-    z.literal('par'),
-    z.literal('phase'),
-    z.literal('salinity'),
-    z.literal('temperature'),
-    z.literal('turbidity'),
-    z.literal('velocity-blue'),
-    z.literal('velocity-green'),
-    z.literal('cubehelix'),
-  ]),
-  min: z.number(),
-  max: z.number(),
-  steps: z.number(),
-  reversed: z.boolean().optional().default(false),
-});
+const colorMapSchema = z
+  .object({
+    name: z.union([
+      z.literal('jet'),
+      z.literal('hsv'),
+      z.literal('hot'),
+      z.literal('cool'),
+      z.literal('spring'),
+      z.literal('summer'),
+      z.literal('autumn'),
+      z.literal('winter'),
+      z.literal('bone'),
+      z.literal('copper'),
+      z.literal('greys'),
+      z.literal('YlOrRd'),
+      z.literal('bluered'),
+      z.literal('RdBu'),
+      z.literal('picnic'),
+      z.literal('rainbow-soft'),
+      z.literal('portland'),
+      z.literal('blackbody'),
+      z.literal('earth'),
+      z.literal('electric'),
+      z.literal('viridis'),
+      z.literal('inferno'),
+      z.literal('magma'),
+      z.literal('plasma'),
+      z.literal('warm'),
+      z.literal('cool'),
+      z.literal('rainbow'),
+      z.literal('bathymetry'),
+      z.literal('cdom'),
+      z.literal('chlorophyll'),
+      z.literal('density'),
+      z.literal('freesurface-blue'),
+      z.literal('freesurface-red'),
+      z.literal('oxygen'),
+      z.literal('par'),
+      z.literal('phase'),
+      z.literal('salinity'),
+      z.literal('temperature'),
+      z.literal('turbidity'),
+      z.literal('velocity-blue'),
+      z.literal('velocity-green'),
+      z.literal('cubehelix'),
+      z.literal('RdYlGn'),
+    ]),
+    min: z.number(),
+    max: z.number(),
+    steps: z.number(),
+    reversed: z.boolean().optional().default(false),
+  })
+  .passthrough();
+
+const COLORMAP_NAME_MAPPING: Record<string, string> = {
+  RdYlGn: 'RdBu',
+  YlOrRd: 'yiorrd',
+  RdBu: 'rdbu',
+};
+
+const normalizeColormapName = (name: string): string => {
+  if (COLORMAP_NAME_MAPPING[name]) {
+    return COLORMAP_NAME_MAPPING[name];
+  }
+
+  return name.toLowerCase();
+};
 
 const getColorStops = (
   name: INamedColorMapOptions['name'],
@@ -64,7 +81,8 @@ const getColorStops = (
 ) => {
   const delta = (max - min) / (steps - 1);
   const stops = new Array(steps * 2);
-  const colors = colormap({ colormap: name, nshades: steps, format: 'rgba' });
+  const normalizedName = normalizeColormapName(name);
+  const colors = colormap({ colormap: normalizedName, nshades: steps, format: 'rgba' });
 
   if (reverse) {
     colors.reverse();

--- a/libs/map/ui-map/src/lib/stac/color-map.model.ts
+++ b/libs/map/ui-map/src/lib/stac/color-map.model.ts
@@ -62,7 +62,8 @@ export interface INamedColorMapOptions {
     | 'turbidity'
     | 'velocity-blue'
     | 'velocity-green'
-    | 'cubehelix';
+    | 'cubehelix'
+    | 'RdYlGn';
   readonly min: number;
   readonly max: number;
   readonly steps: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "6.1.6",
         "@tanstack/react-query": "5.50.1",
         "apexcharts": "4.2.0",
-        "axios": "1.7.4",
+        "axios": "1.13.5",
         "clsx": "2.1.1",
         "colormap": "2.3.2",
         "date-fns": "3.6.0",
@@ -13410,12 +13410,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -16569,7 +16570,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -18479,15 +18479,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -18534,12 +18535,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "6.1.6",
         "@tanstack/react-query": "5.50.1",
         "apexcharts": "4.2.0",
-        "axios": "1.13.5",
+        "axios": "1.7.4",
         "clsx": "2.1.1",
         "colormap": "2.3.2",
         "date-fns": "3.6.0",
@@ -13410,13 +13410,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@mui/material": "6.1.6",
     "@tanstack/react-query": "5.50.1",
     "apexcharts": "4.2.0",
-    "axios": "1.13.5",
+    "axios": "1.7.4",
     "clsx": "2.1.1",
     "colormap": "2.3.2",
     "date-fns": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@mui/material": "6.1.6",
     "@tanstack/react-query": "5.50.1",
     "apexcharts": "4.2.0",
-    "axios": "1.7.4",
+    "axios": "1.13.5",
     "clsx": "2.1.1",
     "colormap": "2.3.2",
     "date-fns": "3.6.0",


### PR DESCRIPTION
This pull request adds support for the `RdYlGn` colormap, improves colormap name normalization and mapping, and updates the `axios` dependency. The changes ensure that new and existing colormap names are handled consistently throughout the codebase.

**Colormap support and normalization:**

* Added `'RdYlGn'` as a valid colormap option in the `INamedColorMapOptions` interface and the color map schema. (`libs/map/ui-map/src/lib/stac/color-map.model.ts` [[1]](diffhunk://#diff-99b6f3011d29e7f2cb226906886e78734945bb24bdbc62775836d87918ccbf37L65-R66) `libs/map/ui-map/src/lib/stac/color-map.color-map.ts` [[2]](diffhunk://#diff-c1b44d508180ab25f105254b6035cd98e0fa13de4666dc60de80f71c8da52855R52-R73)
* Implemented a `COLORMAP_NAME_MAPPING` and `normalizeColormapName` function to map and normalize colormap names, ensuring compatibility with the underlying colormap library. (`libs/map/ui-map/src/lib/stac/color-map.color-map.ts` [libs/map/ui-map/src/lib/stac/color-map.color-map.tsR52-R73](diffhunk://#diff-c1b44d508180ab25f105254b6035cd98e0fa13de4666dc60de80f71c8da52855R52-R73))
* Updated the `getColorStops` function to use the normalized colormap name, improving robustness when handling various colormap inputs. (`libs/map/ui-map/src/lib/stac/color-map.color-map.ts` [libs/map/ui-map/src/lib/stac/color-map.color-map.tsL67-R85](diffhunk://#diff-c1b44d508180ab25f105254b6035cd98e0fa13de4666dc60de80f71c8da52855L67-R85))
